### PR TITLE
Add Django's SECRET_KEY to default patterns

### DIFF
--- a/clouseau/patterns/default.txt
+++ b/clouseau/patterns/default.txt
@@ -18,6 +18,7 @@ cfpb
 [0-9]{12}(?:[0-9]{3})?
 # Private key
 -----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----
+SECRET_KEY
 
 #Dangerous-Functions-API
 eval


### PR DESCRIPTION
This is a simple change to add the `SECRET_KEY` variable in a Django project's `settings.py` to the default patterns. The `SECRET_KEY` is [mostly used by Django to seed transient values](http://stackoverflow.com/a/15383766).