### PR TITLE
Link to a post-commit hook that uses OS X Notification Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ my username=foo  Line:1
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 ```
 
+Clouseau's output can also [be sent to the Mac OS X Notification Center via post-commit hook](https://github.com/willbarton/clouseau-notification-hook/blob/master/post-commit.notification), which is useful for users of GitHub's GUI client for Mac.
+
 ### Running with Docker
 
 Clouseau is now in the Docker index and you can run it with a simple docker command:


### PR DESCRIPTION
This adds a link to a post-commit hook example I created that sends the Clouseau result to Mac OS X's Notification Center.

Without this, if someone is using the Mac OS X GUI client for GitHub, they don't see the Clouseau results at all. This changes that. There are limitations, of course — if there's a match, the most Notification Center has room to show is that there was a match. But it's still better than not having Clouseau at all.
