### PR TITLE
Add npm secret key to default patterns

### DIFF
--- a/clouseau/patterns/default.txt
+++ b/clouseau/patterns/default.txt
@@ -19,7 +19,7 @@ cfpb
 # Private key
 -----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----
 SECRET_KEY
-
+_auth(Token)?=.+
 #Dangerous-Functions-API
 eval
 exec

--- a/clouseau/patterns/default.txt
+++ b/clouseau/patterns/default.txt
@@ -1,26 +1,32 @@
 # The current implementation supports Posix extended regular expressions
 # http://www.regular-expressions.info/posix.html
 # Clouseau also only highlights the first matched group
+
+# Misc. credential patterns
 password[ ]*=[ ]*.+
 pass[ ]*=[ ]*.+
 pwd[ ]*=[ ]*.+
 username[ ]*=[ ]*.+
 uname[ ]*=[ ]*.+
-# ssn 
+
+# SSNs
 [0-9]{3}[\.\-][0-9]{2}[\.\-][0-9]{4}
-\.gov
-cfpb
-#-IP Address
+
+# IP addresses
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}
-#-Email address
+
+# Email addresses
 [A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z]{2,4}
-#-Credit card
+
+# Credit cards
 [0-9]{12}(?:[0-9]{3})?
-# Private key
+
+# Private keys
 -----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----
 SECRET_KEY
 _auth(Token)?=.+
-#Dangerous-Functions-API
+
+# Risky business
 eval
 exec
 random.random
@@ -28,3 +34,6 @@ hash
 raw_input
 pickle
 
+# CFPB-specific concerns
+\.gov
+cfpb


### PR DESCRIPTION
The old format in `.npmrc` files was `_auth="XXXXXXXXXXXXXXXXX="`. The new format is `_authToken=XXXXX-XXXXXX-XXXXXX`. The included regex should cover both.

I also cleaned up the file a bit.